### PR TITLE
[Fix] 누수 해결 (유저를 포인터로 변경)

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -24,10 +24,10 @@ class Channel {
 		std::string	_channelMode;
 
 	public:
-		Channel(User& user, std::string name);
+		Channel(User* user, std::string name);
 		~Channel();
 
-		void		joinNewUser(User user);
+		void		joinNewUser(User* user);
 		bool		isOperator(std::string nickname);
 		bool		isUserInChannel(std::string nickname);
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/29 16:35:50 by san               #+#    #+#             */
-/*   Updated: 2023/01/07 15:03:26 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:09:47 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,7 +74,7 @@ class Server {
 		Channel&	findChannel(std::string channelName);
 		User*		findUser(std::string nickname);
 		User*		findUser(int clientFd);
-		void		checkIsVerified(User& user);
+		void		checkIsVerified(User* user);
 
 	public:
 		Server(char* port, char* password);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/29 16:35:50 by san               #+#    #+#             */
-/*   Updated: 2023/01/07 02:41:55 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:03:26 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,39 +41,39 @@ class Server {
 
 		void		acceptClient(void);
 
-		void		sendMessage(User& user, std::string str);
-		void		sendMessage(User& sender, User& receiver, std::string str);
-		void		sendMessageBroadcast(int mode, Channel& ch, User& sender, std::string str);
+		void		sendMessage(User* user, std::string str);
+		void		sendMessage(User* sender, User* receiver, std::string str);
+		void		sendMessageBroadcast(int mode, Channel& ch, User* sender, std::string str);
 
 		void		receiveFirstClientMessage(int clientFd);
 		void		receiveClientMessage(int clientSocket);
 		std::string	concatMessage(int clientSocket);
-		void		parseMessageStream(User& user, const std::string& fullMsg);
+		void		parseMessageStream(User* user, const std::string& fullMsg);
 		void		setUserDisconnectByFd(int client_fd);
 		void		disconnectClients();
 
-		void		commandCAP(User& user, stringVector& parameters);
-		void		commandPASS(User& user, stringVector& parameters);
-		void		commandNICK(User& user, stringVector& parameters);
-		void		commandUSER(User& user, stringVector& parameters);
-		void		commandPING(User& user, stringVector& parameters);
-		void		commandPONG(User& user, stringVector& parameters);
-		void		commandJOIN(User& user, stringVector& parameters);
-		void		commandTOPIC(User& user, stringVector& parameters);
-		void		commandNAMES(User& user, stringVector& parameters);
-		void		commandMSG(User& user, stringVector& parameters);
-		void		commandMODE(User& user, stringVector& parameters);
-		void		commandPART(User& user, stringVector& parameters);
-		void		commandQUIT(User& user, stringVector& parameters);
-		void		commandKICK(User& user, stringVector& parameters);
-		void		commandWHO(User& user, stringVector& parameters);
+		void		commandCAP(User* user, stringVector& parameters);
+		void		commandPASS(User* user, stringVector& parameters);
+		void		commandNICK(User* user, stringVector& parameters);
+		void		commandUSER(User* user, stringVector& parameters);
+		void		commandPING(User* user, stringVector& parameters);
+		void		commandPONG(User* user, stringVector& parameters);
+		void		commandJOIN(User* user, stringVector& parameters);
+		void		commandTOPIC(User* user, stringVector& parameters);
+		void		commandNAMES(User* user, stringVector& parameters);
+		void		commandMSG(User* user, stringVector& parameters);
+		void		commandMODE(User* user, stringVector& parameters);
+		void		commandPART(User* user, stringVector& parameters);
+		void		commandQUIT(User* user, stringVector& parameters);
+		void		commandKICK(User* user, stringVector& parameters);
+		void		commandWHO(User* user, stringVector& parameters);
 
 		bool		isChannel(std::string channelName);
 		bool		isServerUser(std::string nickname);
 		bool		isServerUser(int clientFd);
 		Channel&	findChannel(std::string channelName);
-		User&		findUser(std::string nickname);
-		User&		findUser(int clientFd);
+		User*		findUser(std::string nickname);
+		User*		findUser(int clientFd);
 		void		checkIsVerified(User& user);
 
 	public:

--- a/includes/User.hpp
+++ b/includes/User.hpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/29 15:55:05 by jiychoi           #+#    #+#             */
-/*   Updated: 2023/01/07 02:33:05 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 14:55:36 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,7 @@ class User {
 
 std::ostream&	operator<<(std::ostream& out, const User& instance);
 
-typedef	std::vector<User>			userVector;
-typedef	std::vector<User>::iterator	userIter;
+typedef	std::vector<User *>				userVector;
+typedef	std::vector<User *>::iterator	userIter;
 
 #endif

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,13 +6,13 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 10:08:55 by san               #+#    #+#             */
-/*   Updated: 2023/01/07 02:41:57 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:41:26 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/Channel.hpp"
 
-Channel::Channel(User& user, std::string channelName) {
+Channel::Channel(User* user, std::string channelName) {
 	_channelOperator.push_back(user);
 	_channelName = channelName;
 	_channelMode = "+nt";
@@ -21,7 +21,7 @@ Channel::Channel(User& user, std::string channelName) {
 Channel::~Channel() {}
 
 // 새로운 유저가 조인하면 이 메서드를 통해서 채널의 userList에 추가한다.
-void	Channel::joinNewUser(User user) {
+void	Channel::joinNewUser(User* user) {
 	_channelUser.push_back(user);
 }
 
@@ -30,7 +30,7 @@ bool	Channel::isOperator(std::string nickname) {
 	userIter	iter;
 
 	for (iter = _channelOperator.begin(); iter < _channelOperator.end(); iter++) {
-		if (!((*iter).getNickname().compare(nickname)))
+		if (!((*iter)->getNickname().compare(nickname)))
 			return true;
 	}
 	return false;
@@ -39,7 +39,7 @@ bool	Channel::isOperator(std::string nickname) {
 bool	Channel::isUserInChannel(std::string nickname) {
 	userIter	iter;
 	for (iter = _channelUser.begin(); iter < _channelUser.end(); iter++) {
-		if (!(*iter).getNickname().compare(nickname))
+		if (!(*iter)->getNickname().compare(nickname))
 			return true;
 	}
 	return false;
@@ -51,9 +51,9 @@ std::string			Channel::getUserList() {
 
 	userList = "= " + _channelName + " :";
 	for (iter = _channelUser.begin(); iter < _channelUser.end(); iter++)
-		userList += ((*iter).getNickname() + " ");
+		userList += ((*iter)->getNickname() + " ");
 	for (iter = _channelOperator.begin(); iter < _channelOperator.end(); iter++)
-		userList += ("@" + (*iter).getNickname() + " ");
+		userList += ("@" + (*iter)->getNickname() + " ");
 	return userList;
 }
 
@@ -85,7 +85,7 @@ void	Channel::deleteNormalUser(std::string nickname){
 	userIter	iter;
 
 	for (iter = _channelUser.begin(); iter < _channelUser.end(); iter++) {
-		if (!(*iter).getNickname().compare(nickname))
+		if (!(*iter)->getNickname().compare(nickname))
 			_channelUser.erase(iter);
 	}
 }
@@ -94,7 +94,7 @@ int		Channel::deleteOperatorUser(std::string nickname) {
 	userIter	iter;
 
 	for (iter = _channelOperator.begin(); iter < _channelOperator.end(); iter++) {
-		if (!(*iter).getNickname().compare(nickname))
+		if (!(*iter)->getNickname().compare(nickname))
 			_channelOperator.erase(iter);
 	}
 	return (_channelOperator.size());

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -6,36 +6,36 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/30 04:09:31 by jiychoi           #+#    #+#             */
-/*   Updated: 2023/01/07 03:23:21 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:07:14 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/Server.hpp"
 
-void	Server::commandCAP(User& user, stringVector& parameters) {
+void	Server::commandCAP(User* user, stringVector& parameters) {
 	if (parameters.size() != 2) throw std::runtime_error(Error(ERR_NEEDMOREPARAMS, CMD_CAP));
 	if (!parameters[1].compare("LS")) sendMessage(user, "CAP * LS");
 }
 
-void	Server::commandPING(User& user, stringVector& parameters) {
-	if (user.getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
+void	Server::commandPING(User* user, stringVector& parameters) {
+	if (user->getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
 	if (parameters.size() < 2) throw std::runtime_error(Error(ERR_NOORIGIN));
 	else if (parameters.size() > 2) throw std::runtime_error(Error(ERR_NOSUCHSERVER, parameters[1]));
 
 	sendMessage(user, "PONG 127.0.0.1 :" + parameters[1]);
 }
 
-void	Server::commandPONG(User& user, stringVector& parameters) {
-	if (user.getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
+void	Server::commandPONG(User* user, stringVector& parameters) {
+	if (user->getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
 	if (parameters.size() < 2) throw std::runtime_error(Error(ERR_NOORIGIN));
 	else if (parameters.size() > 2) throw std::runtime_error(Error(ERR_NOSUCHSERVER, parameters[1]));
 }
 
-void	Server::commandQUIT(User& user, stringVector& parameters) {
-	std::string		quitUserHostname = user.getHostname();
-	std::string		quitUserNickname = user.getNickname();
+void	Server::commandQUIT(User* user, stringVector& parameters) {
+	std::string		quitUserHostname = user->getHostname();
+	std::string		quitUserNickname = user->getNickname();
 	std::string		quitMsg = ft_getStringAfterColon(parameters);
-	stringVector&	channelList = user.getChannelList();
+	stringVector&	channelList = user->getChannelList();
 
 	sendMessage(user, ErrorReply(":Closing Link:", quitUserHostname, "(Quit: " + quitMsg + ")"));
 	for (stringIter iter = channelList.begin(); iter < channelList.end(); iter++) {
@@ -45,17 +45,17 @@ void	Server::commandQUIT(User& user, stringVector& parameters) {
 		if (ch.isOperator(quitUserNickname)) ch.deleteOperatorUser(quitUserNickname);
 		else ch.deleteNormalUser(quitUserNickname);
 	}
-	user.setIsDisconnected(true);
+	user->setIsDisconnected(true);
 }
 
-void	Server::commandWHO(User& user, stringVector& parameters) {
+void	Server::commandWHO(User* user, stringVector& parameters) {
 	if (parameters.size() != 2) throw std::runtime_error(Error(ERR_NEEDMOREPARAMS, CMD_WHO));
 
 	try {
-		User&	userFound = findUser(parameters[1]);
-		sendMessage(user, Reply(RPL_WHOREPLY, user.getNickname(),
-			"* ~" + userFound.getUsername() + " " + userFound.getHostname() + " 127.0.0.1 " + parameters[1] + " H :0 " + userFound.getUsername()));
-		sendMessage(user,Reply(RPL_ENDOFWHO, user.getNickname() + " " + parameters[1]));
+		User*	userFound = findUser(parameters[1]);
+		sendMessage(user, Reply(RPL_WHOREPLY, user->getNickname(),
+			"* ~" + userFound->getUsername() + " " + userFound->getHostname() + " 127.0.0.1 " + parameters[1] + " H :0 " + userFound->getUsername()));
+		sendMessage(user, Reply(RPL_ENDOFWHO, user->getNickname() + " " + parameters[1]));
 	} catch (std::exception e) {
 		throw std::runtime_error(Error(ERR_NOSUCHSERVER, parameters[1]));
 	}

--- a/src/CommandAuth.cpp
+++ b/src/CommandAuth.cpp
@@ -6,61 +6,61 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/02 21:49:06 by jiychoi           #+#    #+#             */
-/*   Updated: 2023/01/07 03:26:03 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:10:18 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/Server.hpp"
 
-void	Server::commandPASS(User& user, stringVector& parameters) {
+void	Server::commandPASS(User* user, stringVector& parameters) {
 	if (parameters.size() != 2) throw std::runtime_error(Error(ERR_NEEDMOREPARAMS, CMD_PASS));
 	if (_password != parameters[1]) throw std::runtime_error(Error(ERR_PASSWDMISMATCH));
 
-	user.setIsVerified(PASS_VERIFIED);
+	user->setIsVerified(PASS_VERIFIED);
 }
 
-void	Server::commandNICK(User& user, stringVector& parameters) {
+void	Server::commandNICK(User* user, stringVector& parameters) {
 	userIter	iter;
 
-	if (!(user.getIsVerified() & PASS_VERIFIED)) throw std::runtime_error(Error(ERR_NOTREGISTERED));
+	if (!(user->getIsVerified() & PASS_VERIFIED)) throw std::runtime_error(Error(ERR_NOTREGISTERED));
 	if (parameters.size() != 2) throw std::runtime_error(Error(ERR_NEEDMOREPARAMS, CMD_NICK));
 	if (parameters[1].length() <= 0 || parameters[1].length() > 9 || !ft_isValidNickname(parameters[1]))
 		throw std::runtime_error(Error(ERR_ERRONEUSNICKNAME, parameters[1]));
 
 	for (iter = _serverUser.begin(); iter < _serverUser.end(); iter++) {
-		if (!(*iter).getNickname().compare(parameters[1]))
+		if (!(*iter)->getNickname().compare(parameters[1]))
 			throw std::runtime_error(Error(ERR_NICKNAMEINUSE, parameters[1]));
 	}
-	user.setNickname(parameters[1]);
-	user.setIsVerified(NICK_VERIFIED);
+	user->setNickname(parameters[1]);
+	user->setIsVerified(NICK_VERIFIED);
 }
 
-void	Server::commandUSER(User& user, stringVector& parameters) {
-	if (!(user.getIsVerified() & PASS_VERIFIED))
+void	Server::commandUSER(User* user, stringVector& parameters) {
+	if (!(user->getIsVerified() & PASS_VERIFIED))
 		throw std::runtime_error(Error(ERR_NOTREGISTERED));
 	if (parameters.size() < 5 || parameters[1].length() <= 0)
 		throw std::runtime_error(Error(ERR_NEEDMOREPARAMS, CMD_NICK));
 
-	user.setUsername(parameters[1]);
-	user.setHostname(parameters[3]);
-	user.setIsVerified(USER_VERIFIED);
+	user->setUsername(parameters[1]);
+	user->setHostname(parameters[3]);
+	user->setIsVerified(USER_VERIFIED);
 	checkIsVerified(user);
 }
 
-void	Server::checkIsVerified(User& user) {
-	if (user.getIsVerified() != ALL_VERIFIED) return;
+void	Server::checkIsVerified(User* user) {
+	if (user->getIsVerified() != ALL_VERIFIED) return;
 
 	sendMessage(user,
-		"001 " + user.getNickname() + " :\033[1;32mWelcome to the " + SERVER_NAME + "\e[0m " + \
-		user.getNickname() + "!" + user.getUsername() + "@" + user.getHostname()
+		"001 " + user->getNickname() + " :\033[1;32mWelcome to the " + SERVER_NAME + "\e[0m " + \
+		user->getNickname() + "!" + user->getUsername() + "@" + user->getHostname()
 	);
 	sendMessage(user,
-		"002 " + user.getNickname() + " :\033[1;32mYour host is " + SERVER_NAME + ", " + "running version 0.1\e[0m"
+		"002 " + user->getNickname() + " :\033[1;32mYour host is " + SERVER_NAME + ", " + "running version 0.1\e[0m"
 	);
 	sendMessage(user,
-		"003 " + user.getNickname() + " :\033[1;32mThis server was created at 2022.12.27\e[0m"
+		"003 " + user->getNickname() + " :\033[1;32mThis server was created at 2022.12.27\e[0m"
 	);
 	sendMessage(user,
-		"004 " + user.getNickname() + " :\033[1;32m" + SERVER_NAME + " 0.1\e[0m"
+		"004 " + user->getNickname() + " :\033[1;32m" + SERVER_NAME + " 0.1\e[0m"
 	);
 }

--- a/src/CommandChannel.cpp
+++ b/src/CommandChannel.cpp
@@ -6,15 +6,15 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 17:53:57 by san               #+#    #+#             */
-/*   Updated: 2023/01/07 03:43:17 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:10:58 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/Server.hpp"
 #include "../includes/Reply.hpp"
 
-void	Server::commandJOIN(User& user, stringVector& parameters) {
-	if (user.getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
+void	Server::commandJOIN(User* user, stringVector& parameters) {
+	if (user->getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
 	if (parameters.size() < 2) throw std::runtime_error(Error(ERR_NEEDMOREPARAMS, CMD_JOIN));
 
 	std::string	channelName = parameters[1];
@@ -24,46 +24,46 @@ void	Server::commandJOIN(User& user, stringVector& parameters) {
 	if (isChannelAvailable) {
 		Channel&	ch = findChannel(channelName);
 		ch.joinNewUser(user);
-		user.addJoinedChannel(channelName);
-		sendMessage(user, Reply(RPL_NAMREPLY, user.getNickname(), ch.getUserList()));
-		sendMessage(user, Reply(RPL_ENDOFNAMES, user.getNickname() + " " + ch.getChannelName()));
+		user->addJoinedChannel(channelName);
+		sendMessage(user, Reply(RPL_NAMREPLY, user->getNickname(), ch.getUserList()));
+		sendMessage(user, Reply(RPL_ENDOFNAMES, user->getNickname() + " " + ch.getChannelName()));
 		sendMessageBroadcast(1, ch, user, "JOIN :" + ch.getChannelName());
 	}
 	else {
 		Channel	ch = Channel(user, channelName);
 		_channelList.push_back(ch);
-		user.addJoinedChannel(channelName);
-		sendMessage(user, Reply(RPL_NAMREPLY, user.getNickname(), ch.getUserList()));
-		sendMessage(user, Reply(RPL_ENDOFNAMES, user.getNickname() + " " + ch.getChannelName()));
+		user->addJoinedChannel(channelName);
+		sendMessage(user, Reply(RPL_NAMREPLY, user->getNickname(), ch.getUserList()));
+		sendMessage(user, Reply(RPL_ENDOFNAMES, user->getNickname() + " " + ch.getChannelName()));
 	}
 }
 
-void	Server::commandTOPIC(User& user, stringVector& parameters) {
-	if (user.getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
+void	Server::commandTOPIC(User* user, stringVector& parameters) {
+	if (user->getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
 	if (parameters.size() < 3) throw std::runtime_error(Error(ERR_NEEDMOREPARAMS, CMD_TOPIC));
 	if (!isChannel(parameters[1])) throw std::runtime_error(Error(ERR_NOSUCHCHANNEL, parameters[1]));
 
 	Channel&	ch = findChannel(parameters[1]);
 	std::string	channelTopic = ft_getStringAfterColon(parameters);
 
-	if (!ch.isOperator(user.getNickname()))
+	if (!ch.isOperator(user->getNickname()))
 		throw std::runtime_error(Error(ERR_CHANOPRIVSNEEDED, parameters[1]));
 	ch.setTopic(channelTopic);
 	sendMessage(user, " TOPIC " + parameters[1] + " " + channelTopic);
 	sendMessageBroadcast(1, ch, user, "TOPIC " + parameters[1] + " " + channelTopic);
 }
 
-void	Server::commandMSG(User& user, stringVector& parameters) {
-	if (user.getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
+void	Server::commandMSG(User* user, stringVector& parameters) {
+	if (user->getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
 
 	if (isChannel(parameters[1])) {
 		Channel&	ch = findChannel(parameters[1]);
-		if (ch.isUserInChannel(user.getNickname()) || ch.isOperator(user.getNickname()))
+		if (ch.isUserInChannel(user->getNickname()) || ch.isOperator(user->getNickname()))
 			sendMessageBroadcast(1, ch, user, "PRIVMSG " + ch.getChannelName() + " " + ft_getStringAfterColon(parameters));
 		return;
 	}
 	if (isServerUser(parameters[1])) {
-		User&	receiver = findUser(parameters[1]);
+		User*	receiver = findUser(parameters[1]);
 
 		sendMessage(user, receiver, "PRIVMSG " + parameters[1] + " " + ft_getStringAfterColon(parameters));
 		return;
@@ -71,7 +71,7 @@ void	Server::commandMSG(User& user, stringVector& parameters) {
 	throw std::runtime_error(Error(ERR_NOSUCHNICK));
 }
 
-void	Server::commandMODE(User& user, stringVector& parameters) {
+void	Server::commandMODE(User* user, stringVector& parameters) {
 	int paramLen = parameters.size();
 	if (paramLen < 2) throw std::runtime_error(Error(ERR_NEEDMOREPARAMS));
 	if (!isServerUser(parameters[1]) && !isChannel(parameters[1]))
@@ -80,13 +80,13 @@ void	Server::commandMODE(User& user, stringVector& parameters) {
 	if (paramLen == 2) {
 		if (isChannel(parameters[1])) {
 			Channel&	ch = findChannel(parameters[1]);
-			sendMessage(user, Reply(RPL_CHANNELMODEIS, user.getNickname(), ch.getChannelName() + " :" + ch.getChannelMode()));
+			sendMessage(user, Reply(RPL_CHANNELMODEIS, user->getNickname(), ch.getChannelName() + " :" + ch.getChannelMode()));
 			return;
 		}
-		if (!parameters[1].compare(user.getNickname()))
-			sendMessage(user, Reply(RPL_UMODEIS, user.getNickname() + " :" + user.getUserMode()));
+		if (!parameters[1].compare(user->getNickname()))
+			sendMessage(user, Reply(RPL_UMODEIS, user->getNickname() + " :" + user->getUserMode()));
 		else
-			throw std::runtime_error(Error(ERR_USERSDONTMATCH, user.getNickname()));
+			throw std::runtime_error(Error(ERR_USERSDONTMATCH, user->getNickname()));
 		return;
 	}
 	if (paramLen == 3) {
@@ -94,50 +94,50 @@ void	Server::commandMODE(User& user, stringVector& parameters) {
 			Channel&	ch = findChannel(parameters[1]);
 			ch.setChannelMode(parameters[2]);
 		} else
-			user.setUserMode(parameters[2]);
-		sendMessage(user, "MODE " + user.getNickname() + " :" + parameters[2]);
+			user->setUserMode(parameters[2]);
+		sendMessage(user, "MODE " + user->getNickname() + " :" + parameters[2]);
 	}
 }
 
-void	Server::commandPART(User& user, stringVector& parameters) {
-	if (user.getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
+void	Server::commandPART(User* user, stringVector& parameters) {
+	if (user->getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
 
 	if (isChannel(parameters[1])) {	// 채널이면
 		Channel&	ch = findChannel(parameters[1]);
 
-		if (ch.isUserInChannel(user.getNickname())) {
-			ch.deleteNormalUser(user.getNickname());
+		if (ch.isUserInChannel(user->getNickname())) {
+			ch.deleteNormalUser(user->getNickname());
 			return;
 		}
-		if (ch.isOperator(user.getNickname())) {
-			ch.deleteOperatorUser(user.getNickname());
+		if (ch.isOperator(user->getNickname())) {
+			ch.deleteOperatorUser(user->getNickname());
 			return;
 		}
 		throw std::runtime_error(Error(ERR_NOTONCHANNEL));
-		user.deleteJoinedChannel(ch.getChannelName());
+		user->deleteJoinedChannel(ch.getChannelName());
 		sendMessageBroadcast(0, ch, user, "PART :" + ch.getChannelName());
 	}
 }
 
-void	Server::commandNAMES(User& user, stringVector& parameters) {
-	if (user.getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
+void	Server::commandNAMES(User* user, stringVector& parameters) {
+	if (user->getIsVerified() != ALL_VERIFIED) throw std::runtime_error(Error(ERR_NOTREGISTERED));
 
 	Channel&	ch = findChannel(parameters[1]);
-	sendMessage(user, Reply(RPL_NAMREPLY, user.getNickname(), ch.getUserList()));
-	sendMessage(user, Reply(RPL_ENDOFNAMES, user.getNickname() + " " + ch.getChannelName()));
+	sendMessage(user, Reply(RPL_NAMREPLY, user->getNickname(), ch.getUserList()));
+	sendMessage(user, Reply(RPL_ENDOFNAMES, user->getNickname() + " " + ch.getChannelName()));
 }
 
-void	Server::commandKICK(User& user, stringVector& parameters) {
+void	Server::commandKICK(User* user, stringVector& parameters) {
 	Channel&	ch = findChannel(parameters[1]);
 
-	if (!ch.isOperator(user.getNickname()))
+	if (!ch.isOperator(user->getNickname()))
 		throw std::runtime_error(Error(ERR_CHANOPRIVSNEEDED));
 	if (!ch.isUserInChannel(parameters[2]))
 		throw std::runtime_error(Error(ERR_NOSUCHNICK));
 
-	User&	kickedUser = findUser(parameters[2]);
+	User*	kickedUser = findUser(parameters[2]);
 	sendMessageBroadcast(0, ch, user, "KICK " + ch.getChannelName() + " " + parameters[2] + ":" + ft_getStringAfterColon(parameters));
-	kickedUser.deleteJoinedChannel(parameters[1]);
+	kickedUser->deleteJoinedChannel(parameters[1]);
 	ch.deleteNormalUser(parameters[2]);
 	ch.deleteOperatorUser(parameters[2]);
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/29 16:35:50 by san               #+#    #+#             */
-/*   Updated: 2023/01/07 15:40:10 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:46:05 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,13 +95,14 @@ void	Server::acceptClient(void) {
 }
 
 void	Server::receiveFirstClientMessage(int clientFd) {
-	User	user;
+	User*	user;
 
 	try {
-		user.setSocketFd(clientFd);
+		user = new User();
+		user->setSocketFd(clientFd);
 		std::string	fullMsg = concatMessage(clientFd);
-		parseMessageStream(&user, fullMsg);
-		_serverUser.push_back(&user);
+		parseMessageStream(user, fullMsg);
+		_serverUser.push_back(user);
 	}	catch (std::exception& e) {
 		std::cout << e.what() << "\n";
 		close(clientFd);
@@ -179,6 +180,7 @@ void	Server::disconnectClients() {
 			}
 			pollIter++;
 		}
+		delete *userIter;
 		userIter = _serverUser.erase(userIter);
 	}
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/29 16:35:50 by san               #+#    #+#             */
-/*   Updated: 2023/01/07 03:40:14 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:40:10 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,8 +100,8 @@ void	Server::receiveFirstClientMessage(int clientFd) {
 	try {
 		user.setSocketFd(clientFd);
 		std::string	fullMsg = concatMessage(clientFd);
-		parseMessageStream(user, fullMsg);
-		_serverUser.push_back(user);
+		parseMessageStream(&user, fullMsg);
+		_serverUser.push_back(&user);
 	}	catch (std::exception& e) {
 		std::cout << e.what() << "\n";
 		close(clientFd);
@@ -111,7 +111,7 @@ void	Server::receiveFirstClientMessage(int clientFd) {
 void	Server::receiveClientMessage(int clientSocket) {
 	try {
 		std::string	fullMsg = concatMessage(clientSocket);
-		User&		user = findUser(clientSocket);
+		User*		user = findUser(clientSocket);
 		parseMessageStream(user, fullMsg);
 	} catch (std::exception& e) {
 		std::cout << e.what() << "\n";
@@ -133,7 +133,7 @@ std::string	Server::concatMessage(int clientSocket) {
 	return fullMsg;
 }
 
-void	Server::parseMessageStream(User& user, const std::string& fullMsg) {
+void	Server::parseMessageStream(User* user, const std::string& fullMsg) {
 	stringVector	commands = ft_split(fullMsg, '\n');
 	stringIter		cmdIter;
 
@@ -166,14 +166,14 @@ void	Server::disconnectClients() {
 	pollFdIter	pollIter;
 
 	while (userIter < _serverUser.end()) {
-		if (!userIter->getIsDisconnected()) {
+		if (!(*userIter)->getIsDisconnected()) {
 			userIter++;
 			continue;
 		}
-		close(userIter->getSocketFd());
+		close((*userIter)->getSocketFd());
 		pollIter = _poll_fds.begin() + 1;
 		while (pollIter < _poll_fds.end()) {
-			if (userIter->getSocketFd() == pollIter->fd) {
+			if ((*userIter)->getSocketFd() == pollIter->fd) {
 				_poll_fds.erase(pollIter);
 				break ;
 			}

--- a/src/ServerSendMessage.cpp
+++ b/src/ServerSendMessage.cpp
@@ -6,39 +6,39 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/05 16:23:22 by jiychoi           #+#    #+#             */
-/*   Updated: 2023/01/07 03:30:40 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:01:42 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/Server.hpp"
 
-void	Server::sendMessage(User& user, std::string str) {
-	int			fd = user.getSocketFd();
-	std::string	strToSend = ":" + user.getNickname() + "!" + user.getNickname()  + "@127.0.0.1 " + str + "\r\n";
+void	Server::sendMessage(User* user, std::string str) {
+	int			fd = user->getSocketFd();
+	std::string	strToSend = ":" + user->getNickname() + "!" + user->getNickname()  + "@127.0.0.1 " + str + "\r\n";
 
 	if (send(fd, (strToSend).c_str(), strToSend.length(), 0) < 0)
 		throw std::runtime_error(Error(ERR_MESSAGESENDFAILED));
 }
 
-void	Server::sendMessage(User& sender, User& receiver, std::string str) {
-	int			fd = receiver.getSocketFd();
-	std::string	strToSend = ":" + sender.getNickname() + "!" + sender.getNickname()  + "@127.0.0.1 " + str + "\r\n";
+void	Server::sendMessage(User* sender, User* receiver, std::string str) {
+	int			fd = receiver->getSocketFd();
+	std::string	strToSend = ":" + sender->getNickname() + "!" + sender->getNickname()  + "@127.0.0.1 " + str + "\r\n";
 
 	if (send(fd, (strToSend).c_str(), strToSend.length(), 0) < 0)
 		throw std::runtime_error(Error(ERR_MESSAGESENDFAILED));
 }
 
-void	Server::sendMessageBroadcast(int mode, Channel& ch, User& sender, std::string str) {
+void	Server::sendMessageBroadcast(int mode, Channel& ch, User* sender, std::string str) {
 	userIter	it;
 	userVector	operUsers = ch.getOperatorVector();
 	userVector	normUsers = ch.getNormalUserVector();
 
 	for (it = operUsers.begin(); it < operUsers.end(); it++) {
-		if (mode == 0 || (*it).getNickname().compare(sender.getNickname()))
+		if (mode == 0 || (*it)->getNickname().compare(sender->getNickname()))
 			sendMessage(sender, *it, str);
 	}
 	for (it = normUsers.begin(); it < normUsers.end(); it++) {
-		if (mode == 0 || (*it).getNickname().compare(sender.getNickname()))
+		if (mode == 0 || (*it)->getNickname().compare(sender->getNickname()))
 			sendMessage(sender, *it, str);
 	}
 }

--- a/src/ServerUtils.cpp
+++ b/src/ServerUtils.cpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/07 00:04:29 by jiychoi           #+#    #+#             */
-/*   Updated: 2023/01/07 03:38:06 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 15:04:11 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@ bool	Server::isServerUser(int clientFd) {
 	userIter	iter;
 
 	for (iter = _serverUser.begin(); iter < _serverUser.end(); iter++) {
-		if (clientFd == iter->getSocketFd())
+		if (clientFd == (*iter)->getSocketFd())
 			return (true);
 	}
 	return (false);
@@ -26,27 +26,27 @@ bool	Server::isServerUser(std::string nickname) {
 	userIter	iter;
 
 	for (iter = _serverUser.begin(); iter < _serverUser.end(); iter++) {
-		if (!(*iter).getNickname().compare(nickname))
+		if (!(*iter)->getNickname().compare(nickname))
 			return true;
 	}
 	return false;
 }
 
-User&	Server::findUser(int clientFd) {
+User*	Server::findUser(int clientFd) {
 	userIter	iter;
 
 	for (iter = _serverUser.begin(); iter < _serverUser.end(); iter++) {
-		if (clientFd == iter->getSocketFd())
+		if (clientFd == (*iter)->getSocketFd())
 			return (*iter);
 	}
 	throw std::runtime_error(Error(ERR_CANNOTFINDUSERFD));
 }
 
-User&	Server::findUser(std::string nickname) {
+User*	Server::findUser(std::string nickname) {
 	userIter iter;
 
 	for (iter = _serverUser.begin(); iter < _serverUser.end(); iter++) {
-		if (!(*iter).getNickname().compare(nickname))
+		if (!(*iter)->getNickname().compare(nickname))
 			return *iter;
 	}
 	throw std::runtime_error(Error(ERR_NOSUCHNICK, nickname));
@@ -56,8 +56,8 @@ void	Server::setUserDisconnectByFd(int clientFd) {
 	userIter	userIter;
 
 	for (userIter = _serverUser.begin(); userIter < _serverUser.end(); userIter++) {
-		if (userIter->getSocketFd() != clientFd) continue;
-		userIter->setIsDisconnected(true);
+		if ((*userIter)->getSocketFd() != clientFd) continue;
+		(*userIter)->setIsDisconnected(true);
 		return;
 	}
 }

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/30 03:50:34 by jiychoi           #+#    #+#             */
-/*   Updated: 2023/01/07 14:49:12 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 16:04:43 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,12 +17,13 @@ User::User(void) {
 	_clientAddressSize = new socklen_t(sizeof(_clientAddress));
 	_isVerified = 0b000;
 	_isDisconnected = false;
+	std::cout << *this << " user created\n";
 }
 
 User::~User(void) {
-	std::cout << *this << " user deleted\n";
 	delete _clientAddress;
 	delete _clientAddressSize;
+	std::cout << *this << " user deleted\n";
 }
 
 User::User(const User& instance) {
@@ -38,6 +39,7 @@ User&	User::operator=(const User& instance) {
 	_hostname = instance.getHostname();
 	_isDisconnected = instance.getIsDisconnected();
 	_isVerified = instance.getIsVerified();
+	std::cout << *this << " user copied\n";
 	return *this;
 }
 

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/30 03:50:34 by jiychoi           #+#    #+#             */
-/*   Updated: 2023/01/07 03:44:04 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 14:49:12 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@ User::User(void) {
 }
 
 User::~User(void) {
+	std::cout << *this << " user deleted\n";
 	delete _clientAddress;
 	delete _clientAddressSize;
 }

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -6,7 +6,7 @@
 /*   By: jiychoi <jiychoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/30 03:50:34 by jiychoi           #+#    #+#             */
-/*   Updated: 2023/01/07 16:04:43 by jiychoi          ###   ########.fr       */
+/*   Updated: 2023/01/07 16:06:19 by jiychoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,13 +17,13 @@ User::User(void) {
 	_clientAddressSize = new socklen_t(sizeof(_clientAddress));
 	_isVerified = 0b000;
 	_isDisconnected = false;
-	std::cout << *this << " user created\n";
+	std::cout << "User created (" << this << ")\n";
 }
 
 User::~User(void) {
 	delete _clientAddress;
 	delete _clientAddressSize;
-	std::cout << *this << " user deleted\n";
+	std::cout << *this << " User deleted (" << this << ")\n";
 }
 
 User::User(const User& instance) {
@@ -39,7 +39,7 @@ User&	User::operator=(const User& instance) {
 	_hostname = instance.getHostname();
 	_isDisconnected = instance.getIsDisconnected();
 	_isVerified = instance.getIsVerified();
-	std::cout << *this << " user copied\n";
+	std::cout << *this << " user copied (" << this << ")\n";
 	return *this;
 }
 


### PR DESCRIPTION
유저 객체가 채널이나 서버에 등록될 때마다 항상 깊은복사 되고 있어서 누수감지하기가 너무 힘들어가지구
최초 1회만 메모리 할당받고 그뒤에는 복사 안 되다가 마지막 한 번만 지워지도록 힙에 할당하고 포인터 다루는 방식으로 바꿨습니다
유저 객체의 참조를 인자로 받던 함수들은 이제 주소를 받습니다
벡터의 push_back에 복사되는 값도 이제 주소값으로 바뀌었습니다